### PR TITLE
feat: Customize Clyde with own username and/or avatarURL

### DIFF
--- a/src/api/clyde.ts
+++ b/src/api/clyde.ts
@@ -1,7 +1,19 @@
 import { getModule } from '../utils/modules';
 
-const clydeModule = getModule(m => m.default?.sendBotMessage);
+const clydeModule = getModule(m => m.default?.receiveMessage);
+const createBotMessageModule = getModule(m => m.createBotMessage);
+const botAvatarsModule = getModule(m => m.default?.BOT_AVATARS);
 
-export function sendReply(channelID: string, content: string): void {
-  clydeModule.default.sendBotMessage(channelID, content);
+botAvatarsModule.default.BOT_AVATARS.enmity = "https://cdn.discordapp.com/attachments/950850316318933004/961398357866217502/101209876.png"
+
+export function sendReply(channelID: string, content: string, username?: string, avatarURL?: string): void {
+  let receivedMessage = createBotMessageModule.createBotMessage(channelID, content);
+
+  receivedMessage.author.username = username ?? "Enmity";
+  receivedMessage.author.avatar = "enmity"; 
+  if (avatarURL) {
+    botAvatarsModule.default.BOT_AVATARS[username] = avatarURL;
+    receivedMessage.author.avatar = username;
+  }
+  clydeModule.default.receiveMessage(channelID, receivedMessage);
 }

--- a/src/api/clyde.ts
+++ b/src/api/clyde.ts
@@ -1,25 +1,26 @@
 import { getModule } from '../utils/modules';
 
-const clydeModule = getModule(m => m.default?.receiveMessage);
-const createBotMessageModule = getModule(m => m.createBotMessage);
-const botAvatarsModule = getModule(m => m.default?.BOT_AVATARS);
+const Messages = getModule(m => m.default?.receiveMessage);
+const BotMessages = getModule(m => m.createBotMessage);
+const Images = getModule(m => m.default?.BOT_AVATARS);
 
-botAvatarsModule.default.BOT_AVATARS.enmity = "https://github.com/enmity-mod.png";
+Images.default.BOT_AVATARS.ENMITY = "https://github.com/enmity-mod.png";
 
 export function sendReply(channelID: string, content: (string | object), username?: string, avatarURL?: string): void {
-  let receivedMessage = createBotMessageModule.createBotMessage(channelID, '');
+  const msg = BotMessages.createBotMessage(channelID, "");
 
-  receivedMessage.author.username = username ?? "Enmity";
-  receivedMessage.author.avatar = username ? username.toLowerCase() : "enmity"; 
+  msg.author.username = username ?? "Enmity";
+  msg.author.avatar = avatarURL ? username : "ENMITY"; 
+  
   if (avatarURL) {
-    botAvatarsModule.default.BOT_AVATARS[username] = avatarURL;
-    receivedMessage.author.avatar = username;
+    Images.default.BOT_AVATARS[username] = avatarURL;
   }
   
   if (typeof content === "string") {
-    receivedMessage.content = content;
+    msg.content = content;
   } else {
-    receivedMessage.embeds.push(content);
+    Object.assign(msg, content);
   }
-  clydeModule.default.receiveMessage(channelID, receivedMessage);
+
+  Messages.default.receiveMessage(channelID, msg);
 }

--- a/src/api/clyde.ts
+++ b/src/api/clyde.ts
@@ -4,7 +4,7 @@ const clydeModule = getModule(m => m.default?.receiveMessage);
 const createBotMessageModule = getModule(m => m.createBotMessage);
 const botAvatarsModule = getModule(m => m.default?.BOT_AVATARS);
 
-botAvatarsModule.default.BOT_AVATARS.enmity = "https://cdn.discordapp.com/attachments/950850316318933004/961398357866217502/101209876.png"
+botAvatarsModule.default.BOT_AVATARS.enmity = "https://github.com/enmity-mod.png";
 
 export function sendReply(channelID: string, content: (string | object), username?: string, avatarURL?: string): void {
   let receivedMessage = createBotMessageModule.createBotMessage(channelID, '');

--- a/src/api/clyde.ts
+++ b/src/api/clyde.ts
@@ -6,14 +6,20 @@ const botAvatarsModule = getModule(m => m.default?.BOT_AVATARS);
 
 botAvatarsModule.default.BOT_AVATARS.enmity = "https://cdn.discordapp.com/attachments/950850316318933004/961398357866217502/101209876.png"
 
-export function sendReply(channelID: string, content: string, username?: string, avatarURL?: string): void {
-  let receivedMessage = createBotMessageModule.createBotMessage(channelID, content);
+export function sendReply(channelID: string, content: (string | object), username?: string, avatarURL?: string): void {
+  let receivedMessage = createBotMessageModule.createBotMessage(channelID, '');
 
   receivedMessage.author.username = username ?? "Enmity";
   receivedMessage.author.avatar = "enmity"; 
   if (avatarURL) {
     botAvatarsModule.default.BOT_AVATARS[username] = avatarURL;
     receivedMessage.author.avatar = username;
+  }
+  
+  if (typeof content === "string") {
+    receivedMessage.content = content;
+  } else {
+    receivedMessage.embeds.push(content);
   }
   clydeModule.default.receiveMessage(channelID, receivedMessage);
 }

--- a/src/api/clyde.ts
+++ b/src/api/clyde.ts
@@ -10,7 +10,7 @@ export function sendReply(channelID: string, content: (string | object), usernam
   let receivedMessage = createBotMessageModule.createBotMessage(channelID, '');
 
   receivedMessage.author.username = username ?? "Enmity";
-  receivedMessage.author.avatar = "enmity"; 
+  receivedMessage.author.avatar = username ? username.toLowerCase() : "enmity"; 
   if (avatarURL) {
     botAvatarsModule.default.BOT_AVATARS[username] = avatarURL;
     receivedMessage.author.avatar = username;


### PR DESCRIPTION
### Description
- Adds two optional parameters to Clyde's `sendReply`, `username` and `avatarURL`, for customizing the reply. By default, the username is "Enmity" and the avatar is Enmity's URL.
- Allows sending embeds instead of plaintext messages
