### PR TITLE
Fixed copy Pluginslist

### DIFF
--- a/src/core/screens/Enmity.tsx
+++ b/src/core/screens/Enmity.tsx
@@ -36,7 +36,7 @@ export function Page({ settings }) {
   };
 
   const Runtime = HermesInternal.getRuntimeProperties();
-  const Plugins = getPlugins();
+  const Plugins = getPlugins().map(p => p.name);
   const Themes = listThemes().map(t => t.name);
 
   return <ScrollView>


### PR DESCRIPTION
Clicking on Plugins copied `**Plugins:** [Object object]` instead of `**Plugins:** PluginName`